### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/app.py
+++ b/app.py
@@ -387,7 +387,14 @@ def create_app():
     @login_required
     @require_company
     def uploaded_file(filename):
-        return send_file(os.path.join(app.config["UPLOAD_FOLDER"], filename))
+        # Sanitize filename and construct full path
+        base_path = app.config["UPLOAD_FOLDER"]
+        safe_filename = secure_filename(filename)
+        fullpath = os.path.normpath(os.path.join(base_path, safe_filename))
+        # Ensure the file is within the upload folder
+        if not fullpath.startswith(os.path.abspath(base_path)):
+            abort(403)
+        return send_file(fullpath)
 
     return app
 


### PR DESCRIPTION
Potential fix for [https://github.com/DenmanBlanchard/RefurbTrack/security/code-scanning/1](https://github.com/DenmanBlanchard/RefurbTrack/security/code-scanning/1)

To fix the problem, we need to ensure that the constructed file path is contained within the intended upload directory. The best way is to normalize the path using `os.path.normpath` and then check that the resulting path starts with the upload folder path. If the check fails, we should abort the request with a 403 or 404 error. This change should be made in the `uploaded_file` function (lines 389-391). We should also use `secure_filename` to sanitize the filename, but normalization and containment checks are still necessary. No new imports are needed, as `os` and `secure_filename` are already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
